### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/invesdwin-util/pom.xml
+++ b/invesdwin-util/pom.xml
@@ -17,7 +17,7 @@
 		<version.maven-processor-plugin>2.2.4</version.maven-processor-plugin>
 		<version.invesdwin-maven-plugin>1.0.0-SNAPSHOT</version.invesdwin-maven-plugin>
 
-		<version.commons-collections>3.2.1</version.commons-collections>
+		<version.commons-collections>3.2.2</version.commons-collections>
 		<version.fest-reflect>1.4.1</version.fest-reflect>
 		<version.fest-util>1.2.5</version.fest-util>
 		<version.fst>2.41</version.fst>
@@ -26,7 +26,7 @@
 		<version.commons-math3>3.2</version.commons-math3>
 		<version.commons-io>2.4</version.commons-io>
 		<version.querydsl>3.6.1</version.querydsl>
-		<version.commons-collections>3.2.1</version.commons-collections>
+		<version.commons-collections>3.2.2</version.commons-collections>
 		<version.commons-beanutils>1.9.2</version.commons-beanutils>
 
 		<version.invesdwin-bom>1.0.0-SNAPSHOT</version.invesdwin-bom>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/